### PR TITLE
added an options to set max allowed unauthenticated commands

### DIFF
--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -74,6 +74,9 @@ class SMTPConnection extends EventEmitter {
         // Error counter - if too many commands in non-authenticated state are used, then disconnect
         this._unauthenticatedCommands = 0;
 
+        // Max allowed unauthenticated commands
+        this._maxAllowedUnauthenticatedCommands = this._server.options.maxAllowedUnauthenticatedCommands || 10;
+
         // Error counter - if too many invalid commands are used, then disconnect
         this._unrecognizedCommands = 0;
 
@@ -120,6 +123,7 @@ class SMTPConnection extends EventEmitter {
                 setTimeout(() => this.connectionReady(), 100);
             }
         });
+        console.log('max', this._maxAllowedUnauthenticatedCommands)
     }
 
     connectionReady(next) {
@@ -430,9 +434,9 @@ class SMTPConnection extends EventEmitter {
         }
 
         // block users that try to fiddle around without logging in
-        if (!this.session.user && this._isSupported('AUTH') && commandName !== 'AUTH') {
+        if (!this.session.user && this._isSupported('AUTH') && commandName !== 'AUTH' && this._maxAllowedUnauthenticatedCommands != -1) {
             this._unauthenticatedCommands++;
-            if (this._unauthenticatedCommands >= 10) {
+            if (this._unauthenticatedCommands >= this._maxAllowedUnauthenticatedCommands) {
                 return this.send(421, 'Error: too many unauthenticated commands');
             }
         }


### PR DESCRIPTION
The use case is when using SMTP with authentication for sending emails (IE not blacklisting AUTH), but smtp receiving is blocked at max 10 unauthenticated commands, which limits the amount of RCPT TO commands it can get.
So setting options.maxAllowedUnauthenticatedCommands to -1 will make it unlimited. Any other number will also work, and the default is 10, as you set it originally.
Thanks