### PR TITLE
Max allowed unauthenticated commands

### DIFF
--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -74,6 +74,9 @@ class SMTPConnection extends EventEmitter {
         // Error counter - if too many commands in non-authenticated state are used, then disconnect
         this._unauthenticatedCommands = 0;
 
+        // Max allowed unauthenticated commands
+        this._maxAllowedUnauthenticatedCommands = this._server.options.maxAllowedUnauthenticatedCommands || 10;
+
         // Error counter - if too many invalid commands are used, then disconnect
         this._unrecognizedCommands = 0;
 
@@ -430,9 +433,9 @@ class SMTPConnection extends EventEmitter {
         }
 
         // block users that try to fiddle around without logging in
-        if (!this.session.user && this._isSupported('AUTH') && commandName !== 'AUTH') {
+        if (!this.session.user && this._isSupported('AUTH') && commandName !== 'AUTH' && this._maxAllowedUnauthenticatedCommands !== -1) {
             this._unauthenticatedCommands++;
-            if (this._unauthenticatedCommands >= 10) {
+            if (this._unauthenticatedCommands >= this._maxAllowedUnauthenticatedCommands) {
                 return this.send(421, 'Error: too many unauthenticated commands');
             }
         }


### PR DESCRIPTION
Use case is for using AUTH for sending emails, but still wanting to receive emails on the same server. Since external SMTP servers will not authenticate, the default 10 max unauthenticated commands allowed will not be enough if there are multiple RCPT TO commands.
maxAllowedUnauthenticatedCommands: -1 will not limit at all.
Any other number will work, with 10 as the default.
Thanks