### PR TITLE
handle missing address in listener handler

### DIFF
--- a/lib/smtp-server.js
+++ b/lib/smtp-server.js
@@ -282,6 +282,12 @@ class SMTPServer extends EventEmitter {
      */
     _onListening() {
         let address = this.server.address();
+        
+        // address will be null if listener is using Unix socket
+        if (address === null) {
+            adress = {address: null, port: null, family: null};
+        }
+        
         this.logger.info(
             //
             {

--- a/lib/smtp-server.js
+++ b/lib/smtp-server.js
@@ -285,7 +285,7 @@ class SMTPServer extends EventEmitter {
         
         // address will be null if listener is using Unix socket
         if (address === null) {
-            adress = {address: null, port: null, family: null};
+            address = {address: null, port: null, family: null};
         }
         
         this.logger.info(


### PR DESCRIPTION
Attempting to use Unix sockets currently leads to the following error:

```
TypeError: Cannot read property 'address' of null
    at SMTPServer._onListening (/usr/local/lib/node_modules/smtp-redis-dropbox/node_modules/smtp-server/lib/smtp-server.js:291:30)
    at Server.server.once (/usr/local/lib/node_modules/smtp-redis-dropbox/node_modules/smtp-server/lib/smtp-server.js:273:52)
    at Server.g (events.js:292:16)
    at emitNone (events.js:86:13)
    at Server.emit (events.js:185:7)
    at emitListeningNT (net.js:1288:10)
    at _combinedTickCallback (internal/process/next_tick.js:77:11)
    at process._tickCallback (internal/process/next_tick.js:104:9)
    at Module.runMain (module.js:606:11)
    at run (bootstrap_node.js:383:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:496:3
```

This is because when using a Unix socket (for example, when using socket activation with systemd), the resulting address is `null`.

It does not appear `smtp-server` is using the address except for logging, so this change simply logs `null` values instead of throwing.