### PR TITLE
localAddress and localPort properties for session object

### DIFF
--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -67,11 +67,16 @@ class SMTPConnection extends EventEmitter {
 
         this.tlsOptions = this.secure && !this.needsUpgrade && this._socket.getCipher ? this._socket.getCipher() : false;
 
-        // Store remote address for later usage
+        // Store local and remote addresses for later usage
+        this.localAddress = (options.localAddress || this._socket.localAddress || '').replace(/^::ffff:/, '');
+        this.localPort = Number(options.localPort || this._socket.localPort) || 0;
         this.remoteAddress = (options.remoteAddress || this._socket.remoteAddress || '').replace(/^::ffff:/, '');
         this.remotePort = Number(options.remotePort || this._socket.remotePort) || 0;
 
         // normalize IPv6 addresses
+        if (this.localAddress && net.isIPv6(this.localAddress)) {
+            this.localAddress = ipv6normalize(this.localAddress);
+        }
         if (this.remoteAddress && net.isIPv6(this.remoteAddress)) {
             this.remoteAddress = ipv6normalize(this.remoteAddress);
         }
@@ -545,6 +550,8 @@ class SMTPConnection extends EventEmitter {
         let session = this.session;
 
         // reset data that might be overwritten
+        session.localAddress = this.localAddress;
+        session.localPort = this.localPort;
         session.remoteAddress = this.remoteAddress;
         session.remotePort = this.remotePort;
         session.clientHostname = this.clientHostname;
@@ -594,6 +601,8 @@ class SMTPConnection extends EventEmitter {
         }
         this._canEmitConnection = false;
         this.emit('connect', {
+            localAddress: this.localAddress,
+            localPort: this.localPort,
             remoteAddress: this.remoteAddress,
             remotePort: this.remotePort,
             hostNameAppearsAs: this.hostNameAppearsAs,


### PR DESCRIPTION
Hi,

It would be nice to have additional properties about local address and port number. I run smtp-server on system with more than one IP address and I miss this information.

I'm not sure if smtp-server should resolve local address too (as `serverHostname` property) but probably it is not so important as it might be resolved later in a handler.
