### PR TITLE
Fix example by allowing clear text authentication

### DIFF
--- a/examples/readme.md
+++ b/examples/readme.md
@@ -6,6 +6,8 @@ Basic usage example. Create `smtp.js`
 const {SMTPServer} = require('smtp-server');
 
 const server = new SMTPServer({
+    // disable STARTTLS to allow authentication in clear text mode
+    disabledCommands: ['STARTTLS', 'AUTH'],
     logger: true,
     onData(stream, session, callback){
         stream.pipe(process.stdout); // print message to console


### PR DESCRIPTION
Previously the example would not accept any incoming emails as`sendmail` would use clear text authentication and the server would reject the message.

Adding `disabledCommands` with an array from `lmtp.js` fixes this issue.