### PR TITLE
fix noop(empty string) command handler

### DIFF
--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -726,7 +726,7 @@ class SMTPConnection extends EventEmitter {
     /**
      * Processes NOOP. Does nothing but keeps the connection alive
      */
-    handler_NOOP(command, callback) {
+    handler_(command, callback) {
         this.send(250, 'OK');
         callback();
     }


### PR DESCRIPTION
Hi, Folks,
Our team had an issue using smtp-server/smpt-connection sending error back "500 Error: command not recognized" when the command is an empty string.
And also found out that there is noop handler "handler_NOOP" but never used,
I believe that it meant to be just "handler_" to support "empty string" command.