### PR TITLE
Access to challenge and challengeResponse (CRAM-MD5)

### DIFF
--- a/lib/sasl.js
+++ b/lib/sasl.js
@@ -364,6 +364,8 @@ const SASL = (module.exports = {
             {
                 method: 'CRAM-MD5',
                 username,
+                challenge,
+                challengeResponse,
                 validatePassword(password) {
                     let hmac = crypto.createHmac('md5', password);
                     return (


### PR DESCRIPTION
Currently the only way to validate a password with CRAM-MD5 method is the`validatePassword()` function.

From [SMTP Server docs](https://nodemailer.com/extras/smtp-server/#handling-authentication):
> **validatePassword** is a function for validating CRAM-MD5 challenge responses. Takes the password of the user as an argument and returns true if the response matches the password

I've added `challenge` and `challengeResponse` variables to `auth` object.
In this way you can write a custom validator _(or send challenge data to a different server for)_ in the `onAuth()` handler.