### PR TITLE
chore: align nodemailer version with mailparser

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dependencies": {
         "base32.js": "0.1.0",
         "ipv6-normalize": "1.0.1",
-        "nodemailer": "6.4.10"
+        "nodemailer": "6.4.11"
     },
     "devDependencies": {
         "chai": "4.2.0",


### PR DESCRIPTION
removes a blocker for me to adopt `mailparser@3` for `emailjs`.