### PR TITLE
Add a space to 334 message reply to be RFC compliant

### DIFF
--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -251,6 +251,11 @@ class SMTPConnection extends EventEmitter {
             this.session.error = payload;
         }
 
+        // Ref. https://datatracker.ietf.org/doc/html/rfc4954#section-4
+        if (payload === '334') {
+            payload += ' ';
+        }
+
         if (this._socket && this._socket.writable) {
             this._socket.write(payload + '\r\n');
             this._server.logger.debug(


### PR DESCRIPTION
Some email client (like for example SOGo) performs a strict check on the length of the 334 reply message which must be 4 characters. As reported in the RFC (https://datatracker.ietf.org/doc/html/rfc4954#section-4) a AUTH LOGIN reply must contain 334 reply code with an additional space appended at the end ("334 ").