### PR TITLE
fix node 18 breakage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+on: push
+
+jobs:
+  test:
+    name: test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [^12, ^14, ^16, ^18]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: install
+        run: npm install
+
+      - name: test
+        run: npm test

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -326,7 +326,6 @@ class SMTPConnection extends EventEmitter {
      */
     _onClose(/* hadError */) {
         if (this._parser) {
-            this._parser.closed = true;
             this._socket.unpipe(this._parser);
             this._parser = false;
         }

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -326,6 +326,10 @@ class SMTPConnection extends EventEmitter {
      */
     _onClose(/* hadError */) {
         if (this._parser) {
+            // node 18 makes this a getter-only property, handled internally 
+            if (this._parser.canSetClosedProp) {
+                this._parser.closed = true;
+            }
             this._socket.unpipe(this._parser);
             this._parser = false;
         }

--- a/lib/smtp-stream.js
+++ b/lib/smtp-stream.js
@@ -31,8 +31,23 @@ class SMTPStream extends Writable {
         // unprocessed bytes from the last parsing iteration (used in data mode)
         this._lastBytes = false;
 
+        // node 18 makes this a getter-only property, handled internally 
+        if (this.canSetClosedProp) {
+            this.closed = false;
+        }
+
         // once the input stream ends, flush all output without expecting the newline
         this.on('finish', () => this._flushData());
+    }
+
+    get canSetClosedProp() {
+        try {
+            const { closed } = this;
+            this.closed = closed;
+            return true;
+        } catch (err) {
+            return false;
+        }
     }
 
     /**

--- a/lib/smtp-stream.js
+++ b/lib/smtp-stream.js
@@ -31,7 +31,6 @@ class SMTPStream extends Writable {
         // unprocessed bytes from the last parsing iteration (used in data mode)
         this._lastBytes = false;
 
-        this.closed = false;
         // once the input stream ends, flush all output without expecting the newline
         this.on('finish', () => this._flushData());
     }

--- a/test/smtp-connection-test.js
+++ b/test/smtp-connection-test.js
@@ -1284,7 +1284,8 @@ describe('SMTPServer', function () {
             });
 
             server.onData = function (stream, session, callback) {
-                stream.pipe(fs.createWriteStream('/dev/null'));
+                const nullDevice = process.platform === 'win32' ? '\\\\.\\NUL' : '/dev/null';
+                stream.pipe(fs.createWriteStream(nullDevice));
                 callback();
             };
 


### PR DESCRIPTION
setting the `closed` property is a fatal operation under node 18. removing the offending lines seems to make no difference for the tests. i've added a github actions workflow for running the tests under various nodes & fixed a test that was failing under windows.