### PR TITLE
expose servername in session

### DIFF
--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -1423,6 +1423,7 @@ class SMTPConnection extends EventEmitter {
             this._upgrading = false;
 
             this.session.tlsOptions = this.tlsOptions = this._socket.getCipher();
+            this.session.servername = this._socket.servername;
             let cipher = this.session.tlsOptions && this.session.tlsOptions.name;
             this._server.logger.info(
                 {


### PR DESCRIPTION
Trying to implement a virtual email host with MTA STS+SNI

Not sure why this is not apart of the `tls.TLSSocket` type definition itself, but if SNI is done, I guess a `servername` property is dynamically added to the TLS Socket by the `tls` module. (see here: https://nodejs.org/api/tls.html#event-secureconnection)

Anyways, this change will expose the servername on the SMTP session