### PR TITLE
SNI + Secure socket interception

### DIFF
--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -1423,6 +1423,7 @@ class SMTPConnection extends EventEmitter {
             this._upgrading = false;
 
             this.session.tlsOptions = this.tlsOptions = this._socket.getCipher();
+            this.session.servername = this._socket.servername;
             let cipher = this.session.tlsOptions && this.session.tlsOptions.name;
             this._server.logger.info(
                 {

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -1435,10 +1435,13 @@ class SMTPConnection extends EventEmitter {
                 'Connection upgraded to TLS using ',
                 cipher || 'N/A'
             );
-            this._socket.pipe(this._parser);
-            if (typeof secureCallback === 'function') {
-                secureCallback();
-            }
+            this._server.onSecure(this._socket, this.session, () => {
+
+                this._socket.pipe(this._parser);
+                if (typeof secureCallback === 'function') {
+                    secureCallback();
+                }
+            })
         });
     }
 }

--- a/lib/smtp-server.js
+++ b/lib/smtp-server.js
@@ -41,7 +41,7 @@ class SMTPServer extends EventEmitter {
         });
 
         // apply shorthand handlers
-        ['onConnect', 'onAuth', 'onMailFrom', 'onRcptTo', 'onData', 'onClose'].forEach(handler => {
+        ['onConnect','onSecure', 'onAuth', 'onMailFrom', 'onRcptTo', 'onData', 'onClose'].forEach(handler => {
             if (typeof this.options[handler] === 'function') {
                 this[handler] = this.options[handler];
             }
@@ -196,7 +196,9 @@ class SMTPServer extends EventEmitter {
     onRcptTo(address, session, callback) {
         setImmediate(callback);
     }
-
+    onSecure(socket, session, callback) {
+        callback();
+    }
     onData(stream, session, callback) {
         let chunklen = 0;
 

--- a/lib/smtp-server.js
+++ b/lib/smtp-server.js
@@ -41,7 +41,7 @@ class SMTPServer extends EventEmitter {
         });
 
         // apply shorthand handlers
-        ['onConnect','onSecure', 'onAuth', 'onMailFrom', 'onRcptTo', 'onData', 'onClose'].forEach(handler => {
+        ['onConnect', 'onSecure', 'onAuth', 'onMailFrom', 'onRcptTo', 'onData', 'onClose'].forEach(handler => {
             if (typeof this.options[handler] === 'function') {
                 this[handler] = this.options[handler];
             }
@@ -197,7 +197,7 @@ class SMTPServer extends EventEmitter {
         setImmediate(callback);
     }
     onSecure(socket, session, callback) {
-        callback();
+        setImmediate(callback);
     }
     onData(stream, session, callback) {
         let chunklen = 0;


### PR DESCRIPTION
This builds upon https://github.com/nodemailer/smtp-server/pull/188 (and can/should replace #188 if accepted)

This just adds an `onSecure` hook that allows library users to intercept secure sockets. Particularly useful for virtual hosting SMTP (which is now practical thanks to MTA STS; can and will just bounce emails that don't comply and use SNI)