### PR TITLE
Do not impose an unauthenticated command limit when auth is optional

### DIFF
--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -496,7 +496,7 @@ class SMTPConnection extends EventEmitter {
         }
 
         // block users that try to fiddle around without logging in
-        if (!this.session.user && this._isSupported('AUTH') && commandName !== 'AUTH' && this._maxAllowedUnauthenticatedCommands !== false) {
+        if (!this.session.user && this._isSupported('AUTH') && !this._server.options.authOptional && commandName !== 'AUTH' && this._maxAllowedUnauthenticatedCommands !== false) {
             this._unauthenticatedCommands++;
             if (this._unauthenticatedCommands >= this._maxAllowedUnauthenticatedCommands) {
                 return this.send(421, 'Error: too many unauthenticated commands');


### PR DESCRIPTION
Proposed as a fix to #161