### PR TITLE
Use npm punycode module instead of deprecated core module

### DIFF
--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -8,7 +8,7 @@ const ipv6normalize = require('ipv6-normalize');
 const sasl = require('./sasl');
 const crypto = require('crypto');
 const os = require('os');
-const punycode = require('punycode');
+const punycode = require('punycode/punycode');
 const EventEmitter = require('events');
 const base32 = require('base32.js');
 

--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
     "dependencies": {
         "base32.js": "0.1.0",
         "ipv6-normalize": "1.0.1",
-        "nodemailer": "6.9.4"
+        "nodemailer": "6.9.7",
+        "punycode": "^2.3.1"
     },
     "devDependencies": {
-        "chai": "4.3.7",
+        "chai": "4.3.10",
         "eslint-config-nodemailer": "1.2.0",
-        "eslint-config-prettier": "9.0.0",
+        "eslint-config-prettier": "9.1.0",
         "grunt": "1.6.1",
         "grunt-cli": "1.4.3",
         "grunt-eslint": "24.3.0",


### PR DESCRIPTION
Hello,

The punycode module has been deprecated in favor of punycode.js (a npm package). See https://nodejs.org/api/punycode.html for some info. It has been added to '--pending-deprecation' warnings since Node 17 and warns now everytime since Node 21 (https://github.com/nodejs/node/blob/v21.0.0/lib/punycode.js).

The fact I specified `punycode/punycode` will look into node_modules instead of targeting global module, if you prefer, you can replace it with `punycode/` only.

Also bumped some minor dependencies :)

Thanks