### PR TITLE
Connection upgraded log space fix

### DIFF
--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -1461,7 +1461,7 @@ class SMTPConnection extends EventEmitter {
                     user: (this.session.user && this.session.user.username) || this.session.user,
                     cipher
                 },
-                'Connection upgraded to TLS using ',
+                'Connection upgraded to TLS using',
                 cipher || 'N/A'
             );
             this._server.onSecure(this._socket, this.session, err => {


### PR DESCRIPTION
Removed a space from the `Connection upgraded to TLS using` log entry.

Before this: `Connection upgraded to TLS using  TLS_AES_256_GCM_SHA384`
After this: `Connection upgraded to TLS using TLS_AES_256_GCM_SHA384`