### PR TITLE
Fix PROXY command bug

### DIFF
--- a/lib/smtp-server.js
+++ b/lib/smtp-server.js
@@ -381,19 +381,24 @@ class SMTPServer extends EventEmitter {
 
                             socketOptions.ignore = this.options.ignoredHosts && this.options.ignoredHosts.includes(socketOptions.remoteAddress);
 
-                            if (!socketOptions.ignore) {
-                                this.logger.info(
-                                    {
-                                        tnx: 'proxy',
-                                        cid: socketOptions.id,
-                                        proxy: params[1].trim().toLowerCase()
-                                    },
-                                    '[%s] PROXY from %s through %s (%s)',
-                                    socketOptions.id,
-                                    params[1].trim().toLowerCase(),
-                                    params[2].trim().toLowerCase(),
-                                    JSON.stringify(params)
-                                );
+                            try {
+                                if (!socketOptions.ignore) {
+                                    this.logger.info(
+                                        {
+                                            tnx: 'proxy',
+                                            cid: socketOptions.id,
+                                            proxy: params[1].trim().toLowerCase()
+                                        },
+                                        '[%s] PROXY from %s through %s (%s)',
+                                        socketOptions.id,
+                                        params[1].trim().toLowerCase(),
+                                        params[2].trim().toLowerCase(),
+                                        JSON.stringify(params)
+                                    );
+                                }
+                            } catch (E) {
+                                socket.end('* BAD Invalid PROXY header\r\n');
+                                return;
                             }
 
                             if (params[3]) {


### PR DESCRIPTION
When PROXY is enabled, you can simply send:
```
PROXY IPV4 1.1.1.1
```

and the _entire process_ will exit, with the error:
```
389 |                                         proxy: params[1].trim().toLowerCase()
390 |                                     },
391 |                                     '[%s] PROXY from %s through %s (%s)',
392 |                                     socketOptions.id,
393 |                                     params[1].trim().toLowerCase(),
394 |                                     params[2].trim().toLowerCase(),
                                                 ^
TypeError: undefined is not an object (evaluating 'params[2].trim')
      at socketReader (/mnt/c/Users/Alex/<private>/node_modules/smtp-server/lib/smtp-server.js:394:44)
      at emit (node:events:84:22)
      at emitReadable_ (internal:streams/readable:396:16)
```

This patch puts a try catch block around the problematic code, and returning an error to the sender if it is invalid.

The reason this happened in the first place is because `params[2]` was never checked to see if it was valid.  Might be worth doing a manual check, but this does fix the issue.

Note: this is not too severe of a bug, as most people have proxy off, and the proxy would send correct data to begin with.