### PR TITLE
feat: added DSN capability to feature list (disabled by default)

### DIFF
--- a/DSN-IMPLEMENTATION.md
+++ b/DSN-IMPLEMENTATION.md
@@ -28,15 +28,31 @@ This patch adds comprehensive DSN (Delivery Status Notification) support to the 
 
 ### 4. Session Data Structure
 Enhanced the session envelope to include DSN information:
+
 ```javascript
 session.envelope = {
     mailFrom: false,
-    rcptTo: [],
+    rcptTo: [
+      {
+        "address": "foo@foo.com",
+        "args": {
+          "NOTIFY": "SUCCESS,FAILURE,DELAY",
+          "ORCPT": "rfc822;foo@foo.com"
+        },
+        "dsn": {
+          "notify": [
+            "SUCCESS",
+            "FAILURE",
+            "DELAY"
+          ],
+          "orcpt": "rfc822;foo@foo.com"
+        },
+        "name": ""
+      }
+    ],
     dsn: {
-        ret: null,      // RET parameter from MAIL FROM (FULL or HDRS)
-        envid: null,    // ENVID parameter from MAIL FROM
-        notify: [],     // NOTIFY parameters from RCPT TO commands
-        orcpt: []       // ORCPT parameters from RCPT TO commands
+        ret: 'FULL',                      // RET parameter from MAIL FROM (FULL or HDRS)
+        envid: 'TEST-ENVELOPE-IDENTIFIER' // ENVID parameter from MAIL FROM
     }
 }
 ```

--- a/DSN-IMPLEMENTATION.md
+++ b/DSN-IMPLEMENTATION.md
@@ -7,8 +7,8 @@ This patch adds comprehensive DSN (Delivery Status Notification) support to the 
 ## Changes Made
 
 ### 1. EHLO Response Enhancement
-- Added `ENHANCEDSTATUSCODES` extension to the EHLO response
-- The extension can be hidden using the `hideENHANCEDSTATUSCODES` option
+- Added `DSN` extension to the EHLO response
+- The extension can be hidden using the `hideDSN` option
 
 ### 2. MAIL FROM DSN Parameters
 - **RET Parameter**: Accepts `FULL` or `HDRS` values
@@ -45,12 +45,12 @@ session.envelope = {
 - RET parameter must be either "FULL" or "HDRS"
 - NOTIFY parameter values must be valid (SUCCESS, FAILURE, DELAY, NEVER)
 - NOTIFY=NEVER cannot be combined with other values
-- All DSN parameters are only processed when ENHANCEDSTATUSCODES extension is supported
+- All DSN parameters are only processed when DSN extension is supported
 
 ## Files Modified
 
 1. **lib/smtp-connection.js**
-   - Added ENHANCEDSTATUSCODES to EHLO response
+   - Added DSN to EHLO response
    - Enhanced `_resetSession()` to include DSN data structure
    - Modified `handler_MAIL()` to process RET and ENVID parameters
    - Modified `handler_RCPT()` to process NOTIFY and ORCPT parameters
@@ -58,7 +58,7 @@ session.envelope = {
 
 2. **test/dsn-test.js** (NEW)
    - Comprehensive test suite for DSN functionality
-   - Tests for EHLO response with ENHANCEDSTATUSCODES
+   - Tests for EHLO response with DSN
    - Tests for MAIL FROM DSN parameter validation
    - Tests for RCPT TO DSN parameter validation
    - Unit tests for parameter parsing
@@ -77,7 +77,7 @@ DATA
 ### Hiding DSN Extension
 ```javascript
 const server = new SMTPServer({
-    hideENHANCEDSTATUSCODES: true,
+    hideDSN: true,
     // ... other options
 });
 ```
@@ -86,7 +86,7 @@ const server = new SMTPServer({
 
 This implementation maintains full backward compatibility:
 - Existing code will continue to work without changes
-- DSN parameters are optional and ignored if ENHANCEDSTATUSCODES is not advertised
+- DSN parameters are optional and ignored if DSN is not advertised
 - All existing SMTP functionality remains unchanged
 
 ## RFC Compliance

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -774,8 +774,8 @@ class SMTPConnection extends EventEmitter {
             dsn: {
                 ret: null,      // RET parameter from MAIL FROM (FULL or HDRS)
                 envid: null,    // ENVID parameter from MAIL FROM
-                notify: [],     // NOTIFY parameters from RCPT TO commands
-                orcpt: []       // ORCPT parameters from RCPT TO commands
+                notify: [],     // NOTIFY parameters from MAIL FROM
+                orcpt: []       // ORCPT parameters from MAIL FROM
             }
         };
 

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -837,7 +837,7 @@ class SMTPConnection extends EventEmitter {
 
         this.hostNameAppearsAs = hostname.toLowerCase();
 
-        let features = ['PIPELINING', '8BITMIME', 'SMTPUTF8', 'ENHANCEDSTATUSCODES'].filter(feature => !this._server.options['hide' + feature]);
+        let features = ['PIPELINING', '8BITMIME', 'SMTPUTF8', 'ENHANCEDSTATUSCODES', 'DSN'].filter(feature => !this._server.options['hide' + feature]);
 
         if (this._server.options.authMethods.length && this._isSupported('AUTH') && !this.session.user) {
             features.push(['AUTH'].concat(this._server.options.authMethods).join(' '));

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -51,6 +51,13 @@ const ENHANCED_STATUS_CODES = {
     556: '5.1.10' // RCPT TO syntax error
 };
 
+// Skip enhanced status codes for initial greeting and HELO/EHLO responses
+const SKIPPED_COMMANDS_FOR_ENHANCED_STATUS_CODES = new Set([
+  'HELO',
+  'EHLO',
+  'LHLO'
+]);
+
 // Context-specific enhanced status code mappings
 const CONTEXTUAL_STATUS_CODES = {
     // Mail transaction specific codes
@@ -192,7 +199,7 @@ class SMTPConnection extends EventEmitter {
         this._setListeners(() => {
             // Check that connection limit is not exceeded
             if (this._server.options.maxClients && this._server.connections.size > this._server.options.maxClients) {
-                return this.send(421, this.name + ' Too many connected clients, try again in a moment');
+                return this.send(421, this.name + ' Too many connected clients, try again in a moment', false);
             }
 
             // Keep a small delay for detecting early talkers
@@ -255,7 +262,7 @@ class SMTPConnection extends EventEmitter {
                 );
 
                 if (err) {
-                    this.send(err.responseCode || 554, err.message);
+                    this.send(err.responseCode || 554, err.message, false);
                     return this.close();
                 }
 
@@ -271,7 +278,8 @@ class SMTPConnection extends EventEmitter {
                         this.name +
                             ' ' +
                             (this._server.options.lmtp ? 'LMTP' : 'ESMTP') +
-                            (this._server.options.banner ? ' ' + this._server.options.banner : '')
+                            (this._server.options.banner ? ' ' + this._server.options.banner : ''),
+                        false
                     );
 
                     if (typeof next === 'function') {
@@ -330,7 +338,7 @@ class SMTPConnection extends EventEmitter {
      *
      * @param {Number} code Response code
      * @param {String|Array} data If data is Array, send a multi-line response
-     * @param {String} context Optional context for enhanced status codes
+     * @param {String|Boolean} context Optional context for enhanced status codes
      */
     send(code, data, context) {
         let payload;
@@ -531,17 +539,17 @@ class SMTPConnection extends EventEmitter {
 
         // If server already closing then ignore commands
         if (this._server._closeTimeout) {
-            return this.send(421, 'Server shutting down');
+            return this.send(421, 'Server shutting down', commandName);
         }
 
         if (!this._ready) {
             // block spammers that send payloads before server greeting
-            return this.send(421, this.name + ' You talk too soon');
+            return this.send(421, this.name + ' You talk too soon', commandName);
         }
 
         // block malicious web pages that try to make SMTP calls from an AJAX request
         if (/^(OPTIONS|GET|HEAD|POST|PUT|DELETE|TRACE|CONNECT) \/.* HTTP\/\d\.\d$/i.test(command)) {
-            return this.send(421, 'HTTP requests not allowed');
+            return this.send(421, 'HTTP requests not allowed', commandName);
         }
 
         if (this._upgrading) {
@@ -566,7 +574,7 @@ class SMTPConnection extends EventEmitter {
                 switch (commandName) {
                     case 'HELO':
                     case 'EHLO':
-                        this.send(500, 'Error: ' + commandName + ' not allowed in LMTP server');
+                        this.send(500, 'Error: ' + commandName + ' not allowed in LMTP server', false);
                         return setImmediate(callback);
                     case 'LHLO':
                         commandName = 'EHLO';
@@ -582,10 +590,10 @@ class SMTPConnection extends EventEmitter {
             // if the user makes more
             this._unrecognizedCommands++;
             if (this._unrecognizedCommands >= 10) {
-                return this.send(421, 'Error: too many unrecognized commands');
+                return this.send(421, 'Error: too many unrecognized commands', commandName);
             }
 
-            this.send(500, 'Error: command not recognized');
+            this.send(500, 'Error: command not recognized', commandName);
             return setImmediate(callback);
         }
 
@@ -599,7 +607,7 @@ class SMTPConnection extends EventEmitter {
         ) {
             this._unauthenticatedCommands++;
             if (this._unauthenticatedCommands >= this._maxAllowedUnauthenticatedCommands) {
-                return this.send(421, 'Error: too many unauthenticated commands');
+                return this.send(421, 'Error: too many unauthenticated commands', commandName);
             }
         }
 
@@ -642,19 +650,21 @@ class SMTPConnection extends EventEmitter {
     /**
      * Gets the appropriate enhanced status code for a given SMTP response code and context
      * @param {Number} code SMTP response code
-     * @param {String} context Optional context for more specific status codes
+     * @param {String|Boolean} context Optional context for more specific status codes
      * @returns {String} Enhanced status code or empty string if not applicable
      */
     _getEnhancedStatusCode(code, context) {
-        if (!this._useEnhancedStatusCodes()) {
+        if (context === false || !this._useEnhancedStatusCodes()) {
+            return '';
+        }
+
+        // Skip 3xx responses as per RFC 2034
+        if (code >= 300 && code < 400) {
             return '';
         }
 
         // Skip enhanced status codes for initial greeting and HELO/EHLO responses
-        // This is handled by checking the context in the calling code
-
-        // Skip 3xx responses as per RFC 2034
-        if (code >= 300 && code < 400) {
+        if (context && SKIPPED_COMMANDS_FOR_ENHANCED_STATUS_CODES.has(context)) {
             return '';
         }
 
@@ -831,7 +841,7 @@ class SMTPConnection extends EventEmitter {
         let hostname = parts[1] || '';
 
         if (parts.length !== 2) {
-            this.send(501, 'Error: syntax: ' + (this._server.options.lmtp ? 'LHLO' : 'EHLO') + ' hostname');
+            this.send(501, 'Error: syntax: ' + (this._server.options.lmtp ? 'LHLO' : 'EHLO') + ' hostname', false);
             return callback();
         }
 
@@ -862,7 +872,7 @@ class SMTPConnection extends EventEmitter {
         }
 
         this._resetSession(); // EHLO is effectively the same as RSET
-        this.send(250, [this.name + ' Nice to meet you, ' + this.clientHostname].concat(features || []));
+        this.send(250, [this.name + ' Nice to meet you, ' + this.clientHostname].concat(features || []), false);
 
         callback();
     }
@@ -875,14 +885,14 @@ class SMTPConnection extends EventEmitter {
         let hostname = parts[1] || '';
 
         if (parts.length !== 2) {
-            this.send(501, 'Error: Syntax: HELO hostname');
+            this.send(501, 'Error: Syntax: HELO hostname', false);
             return callback();
         }
 
         this.hostNameAppearsAs = hostname.toLowerCase();
 
         this._resetSession(); // HELO is effectively the same as RSET
-        this.send(250, this.name + ' Nice to meet you, ' + this.clientHostname);
+        this.send(250, this.name + ' Nice to meet you, ' + this.clientHostname, false);
 
         callback();
     }

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -770,14 +770,14 @@ class SMTPConnection extends EventEmitter {
         // reset transaction properties
         session.envelope = {
             mailFrom: false,
-            rcptTo: [],
-            dsn: {
-                ret: null,      // RET parameter from MAIL FROM (FULL or HDRS)
-                envid: null,    // ENVID parameter from MAIL FROM
-                notify: [],     // NOTIFY parameters from MAIL FROM
-                orcpt: []       // ORCPT parameters from MAIL FROM
-            }
+            rcptTo: []
         };
+
+        if (!this._server.options.hideDSN)
+            session.envelope.dsn = {
+                ret: null,  // RET parameter from MAIL FROM (FULL or HDRS)
+                envid: null // ENVID parameter from MAIL FROM
+            };
 
         session.transaction = this._transactionCounter + 1;
     }

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -1343,8 +1343,8 @@ class SMTPConnection extends EventEmitter {
             return callback();
         }
 
-        // Process DSN parameters if ENHANCEDSTATUSCODES is supported
-        if (!this._server.options.hideENHANCEDSTATUSCODES) {
+        // Process DSN parameters if DSN is supported
+        if (!this._server.options.hideDSN) {
             // Validate RET parameter
             if (parsed.args.RET) {
                 const ret = parsed.args.RET.toUpperCase();
@@ -1391,8 +1391,8 @@ class SMTPConnection extends EventEmitter {
             return callback();
         }
 
-        // Process DSN parameters if ENHANCEDSTATUSCODES is supported
-        if (!this._server.options.hideENHANCEDSTATUSCODES) {
+        // Process DSN parameters if DSN is supported
+        if (!this._server.options.hideDSN) {
             // Validate NOTIFY parameter
             if (parsed.args.NOTIFY) {
                 const notify = parsed.args.NOTIFY.toUpperCase();

--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -22,12 +22,15 @@ const ENHANCED_STATUS_CODES = {
     214: '2.0.0', // Help message
     220: '2.0.0', // Service ready
     221: '2.0.0', // Service closing transmission channel
+    235: '2.7.0', // Authentication successful
     250: '2.0.0', // Requested mail action okay, completed
     251: '2.1.5', // User not local; will forward
     252: '2.1.5', // Cannot VRFY user, but will accept message
+    334: '3.7.0', // Server challenge for authentication
     354: '2.0.0', // Start mail input; end with <CRLF>.<CRLF>
 
     // Temporary failure codes (4xx)
+    420: '4.4.2', // Timeout or connection lost (non-standard, used by some servers)
     421: '4.4.2', // Service not available, closing transmission channel
     450: '4.2.1', // Requested mail action not taken: mailbox unavailable
     451: '4.3.0', // Requested action aborted: local error in processing
@@ -41,14 +44,19 @@ const ENHANCED_STATUS_CODES = {
     503: '5.5.1', // Bad sequence of commands
     504: '5.5.4', // Command parameter not implemented
     521: '5.3.2', // Machine does not accept mail
+    523: '5.3.4', // Message size exceeds server limit (non-standard, used by some servers)
     530: '5.7.0', // Authentication required
     535: '5.7.8', // Authentication credentials invalid
+    538: '5.7.0', // Must issue a STARTTLS command first (non-standard)
     550: '5.1.1', // Requested action not taken: mailbox unavailable
     551: '5.1.6', // User not local; please try forwarding
     552: '5.2.2', // Requested mail action aborted: exceeded storage allocation
     553: '5.1.3', // Requested action not taken: mailbox name not allowed
     554: '5.6.0', // Transaction failed
-    556: '5.1.10' // RCPT TO syntax error
+    555: '5.5.4', // MAIL FROM/RCPT TO parameters not recognized or not implemented
+    556: '5.1.10', // RCPT TO syntax error (non-standard)
+    557: '5.7.1', // Delivery not authorized (non-standard, used by some servers)
+    558: '5.2.3' // Message too large for recipient (non-standard, used by some servers)
 };
 
 // Skip enhanced status codes for initial greeting and HELO/EHLO responses
@@ -674,7 +682,27 @@ class SMTPConnection extends EventEmitter {
         }
 
         // Use default mapping
-        return ENHANCED_STATUS_CODES[code] || '';
+        if (ENHANCED_STATUS_CODES[code]) {
+            return ENHANCED_STATUS_CODES[code];
+        }
+
+        // 2xx fallback
+        if (code >= 200 && code < 300) {
+            return '2.0.0';
+        }
+
+        // 4xx (transient failure)
+        if (code >= 400 && code < 500) {
+            return '4.0.0';
+        }
+
+        // 5xx (permanent failure)
+        if (code >= 500) {
+            return '5.0.0';
+        }
+
+        // safeguard (non-spec; but should never occur)
+        return '';
     }
 
     /**

--- a/lib/smtp-server.js
+++ b/lib/smtp-server.js
@@ -41,6 +41,11 @@ class SMTPServer extends EventEmitter {
             this.options.hideENHANCEDSTATUSCODES = true;
         }
 
+        // set default value for hideDSN to true (disable delivery status notifications by default)
+        if (this.options.hideDSN === undefined) {
+            this.options.hideDSN = true;
+        }
+
         this.logger = shared.getLogger(this.options, {
             component: this.options.component || 'smtp-server'
         });

--- a/test/dsn-test.js
+++ b/test/dsn-test.js
@@ -76,10 +76,11 @@ describe('DSN (Delivery Status Notification) Support', function () {
     });
 
     describe('EHLO Response', function () {
-        it('should include ENHANCEDSTATUSCODES in features list', function (done) {
+        it('should include ENHANCEDSTATUSCODES and DSN in features list', function (done) {
             let server = new SMTPServer({
                 disabledCommands: ['AUTH'],
-                hideENHANCEDSTATUSCODES: false
+                hideENHANCEDSTATUSCODES: false,
+                hideDSN: false
             });
 
             // Mock connection for testing EHLO handler
@@ -108,9 +109,10 @@ describe('DSN (Delivery Status Notification) Support', function () {
                 expect(sentResponse.code).to.equal(250);
                 expect(sentResponse.message).to.be.an('array');
 
-                // Check if ENHANCEDSTATUSCODES is in the features
+                // Check if ENHANCEDSTATUSCODES and DSN is in the features
                 const features = sentResponse.message.slice(1); // Skip the greeting
                 expect(features).to.include('ENHANCEDSTATUSCODES');
+                expect(features).to.include('DSN');
 
                 done();
             });
@@ -155,12 +157,52 @@ describe('DSN (Delivery Status Notification) Support', function () {
                 done();
             });
         });
+
+        it('should hide DSN when hideDSN is true', function (done) {
+            let server = new SMTPServer({
+                disabledCommands: ['AUTH'],
+                hideDSN: true
+            });
+
+            // Mock connection for testing EHLO handler
+            let mockConnection = new SMTPConnection(server, {
+                on() {},
+                write() {},
+                end() {},
+                localAddress: '127.0.0.1',
+                localPort: 25,
+                remoteAddress: '127.0.0.1',
+                remotePort: 12345
+            });
+
+            mockConnection.clientHostname = 'test.example.com';
+            mockConnection.name = 'test-server';
+
+            // Mock the send method to capture the response
+            let sentResponse = null;
+            mockConnection.send = function (code, message) {
+                sentResponse = { code, message };
+            };
+
+            // Test EHLO handler
+            mockConnection.handler_EHLO('EHLO test.example.com', function () {
+                expect(sentResponse).to.exist;
+                expect(sentResponse.code).to.equal(250);
+                expect(sentResponse.message).to.be.an('array');
+
+                // Check if DSN is NOT in the features
+                const features = sentResponse.message.slice(1); // Skip the greeting
+                expect(features).to.not.include('DSN');
+
+                done();
+            });
+        });
     });
 
     describe('MAIL FROM DSN Parameter Validation', function () {
         it('should accept valid RET=FULL parameter', function (done) {
             let server = new SMTPServer({
-                hideENHANCEDSTATUSCODES: false,
+                hideDSN: false,
                 onMailFrom(address, session, callback) {
                     expect(session.envelope.dsn.ret).to.equal('FULL');
                     expect(address.args.RET).to.equal('FULL');
@@ -195,7 +237,7 @@ describe('DSN (Delivery Status Notification) Support', function () {
 
         it('should reject invalid RET parameter', function (done) {
             let server = new SMTPServer({
-                hideENHANCEDSTATUSCODES: false,
+                hideDSN: false,
                 onMailFrom(address, session, callback) {
                     callback();
                 }
@@ -229,7 +271,7 @@ describe('DSN (Delivery Status Notification) Support', function () {
 
         it('should accept ENVID parameter', function (done) {
             let server = new SMTPServer({
-                hideENHANCEDSTATUSCODES: false,
+                hideDSN: false,
                 onMailFrom(address, session, callback) {
                     expect(session.envelope.dsn.envid).to.equal('test-envelope-123');
                     expect(address.args.ENVID).to.equal('test-envelope-123');
@@ -266,7 +308,7 @@ describe('DSN (Delivery Status Notification) Support', function () {
     describe('RCPT TO DSN Parameter Validation', function () {
         it('should accept valid NOTIFY=SUCCESS parameter', function (done) {
             let server = new SMTPServer({
-                hideENHANCEDSTATUSCODES: false,
+                hideDSN: false,
                 onMailFrom(address, session, callback) {
                     callback();
                 },
@@ -305,7 +347,7 @@ describe('DSN (Delivery Status Notification) Support', function () {
 
         it('should reject invalid NOTIFY parameter', function (done) {
             let server = new SMTPServer({
-                hideENHANCEDSTATUSCODES: false,
+                hideDSN: false,
                 onMailFrom(address, session, callback) {
                     callback();
                 },
@@ -343,7 +385,7 @@ describe('DSN (Delivery Status Notification) Support', function () {
 
         it('should reject NOTIFY=NEVER combined with other values', function (done) {
             let server = new SMTPServer({
-                hideENHANCEDSTATUSCODES: false,
+                hideDSN: false,
                 onMailFrom(address, session, callback) {
                     callback();
                 },
@@ -381,7 +423,7 @@ describe('DSN (Delivery Status Notification) Support', function () {
 
         it('should accept ORCPT parameter', function (done) {
             let server = new SMTPServer({
-                hideENHANCEDSTATUSCODES: false,
+                hideDSN: false,
                 onMailFrom(address, session, callback) {
                     callback();
                 },

--- a/test/dsn-test.js
+++ b/test/dsn-test.js
@@ -70,8 +70,6 @@ describe('DSN (Delivery Status Notification) Support', function () {
             expect(conn.session.envelope.dsn).to.exist;
             expect(conn.session.envelope.dsn.ret).to.be.null;
             expect(conn.session.envelope.dsn.envid).to.be.null;
-            expect(conn.session.envelope.dsn.notify).to.be.an('array');
-            expect(conn.session.envelope.dsn.orcpt).to.be.an('array');
         });
     });
 


### PR DESCRIPTION
This is a bugfix per our work with DSN and ENHANCEDSTATUSCODES.

Right now DSN is not working in `smtp-server` because of this line:

<https://github.com/nodemailer/nodemailer/blob/8033604aed6d107dd9d44f6ede4508de3393e504/lib/smtp-connection/index.js#L1110>

(we don't advertise DSN support right now, but we need to)