### PR TITLE
chore: remove base32.js dep

### DIFF
--- a/lib/smtp-connection.js
+++ b/lib/smtp-connection.js
@@ -10,7 +10,6 @@ const crypto = require('crypto');
 const os = require('os');
 const punycode = require('punycode.js');
 const EventEmitter = require('events');
-const base32 = require('base32.js');
 
 const SOCKET_TIMEOUT = 60 * 1000;
 
@@ -105,7 +104,7 @@ class SMTPConnection extends EventEmitter {
 
         options = options || {};
         // Random session ID, used for logging
-        this.id = options.id || base32.encode(crypto.randomBytes(10)).toLowerCase();
+        this.id = options.id || BigInt('0x' + crypto.randomBytes(10).toString('hex')).toString(32).padStart(16, '0');
 
         this.ignore = options.ignore;
 

--- a/lib/smtp-server.js
+++ b/lib/smtp-server.js
@@ -8,7 +8,6 @@ const EventEmitter = require('events');
 const shared = require('nodemailer/lib/shared');
 const punycode = require('punycode.js');
 const crypto = require('crypto');
-const base32 = require('base32.js');
 
 const CLOSE_TIMEOUT = 30 * 1000; // how much to wait until pending connections are terminated
 
@@ -354,7 +353,7 @@ class SMTPServer extends EventEmitter {
 
     _handleProxy(socket, callback) {
         let socketOptions = {
-            id: base32.encode(crypto.randomBytes(10)).toLowerCase()
+            id: BigInt('0x' + crypto.randomBytes(10).toString('hex')).toString(32).padStart(16, '0')
         };
 
         if (

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
             "version": "3.18.0",
             "license": "MIT-0",
             "dependencies": {
-                "base32.js": "0.1.0",
                 "ipv6-normalize": "1.0.1",
                 "nodemailer": "7.0.11",
                 "punycode.js": "2.3.1"
@@ -389,15 +388,6 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/base32.js": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
-            "integrity": "sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.12.0"
-            }
         },
         "node_modules/binary-extensions": {
             "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "author": "Andris Reinman",
     "license": "MIT-0",
     "dependencies": {
-        "base32.js": "0.1.0",
         "ipv6-normalize": "1.0.1",
         "nodemailer": "7.0.11",
         "punycode.js": "2.3.1"


### PR DESCRIPTION
Just one dep less, generating ids is trivially inlinable
The perf of those is identical

This is not identical, as it now generates ids in 10 digits + 22 letters space, not in 6 digits + 26 letters space as `base32.js`

The documented usage is logging though, so this should be fine

If you don't care about them being uniformly random, then base36 could be used via `toString(36)`.