### PR TITLE
  fix: prevent uncaughtException when client disconnects before PROXY header

### DIFF
--- a/lib/smtp-server.js
+++ b/lib/smtp-server.js
@@ -76,7 +76,11 @@ class SMTPServer extends EventEmitter {
             this.server = net.createServer(this.options, socket => {
                 this._handleProxy(socket, (err, socketOptions) => {
                     if (err) {
-                        // ignore, should not happen
+                        // PROXY header could not be read (client dropped the
+                        // connection or sent garbage). The socket is already
+                        // closing/closed and guarded against late errors in
+                        // _handleProxy; just don't proceed to connect().
+                        return;
                     }
                     if (this.options.secured) {
                         return this.connect(socket, socketOptions);
@@ -93,7 +97,9 @@ class SMTPServer extends EventEmitter {
             this.server = net.createServer(this.options, socket =>
                 this._handleProxy(socket, (err, socketOptions) => {
                     if (err) {
-                        // ignore, should not happen
+                        // socket already closing/closed and guarded in
+                        // _handleProxy; just don't proceed to connect()
+                        return;
                     }
                     this.connect(socket, socketOptions);
                 })
@@ -353,7 +359,9 @@ class SMTPServer extends EventEmitter {
 
     _handleProxy(socket, callback) {
         let socketOptions = {
-            id: BigInt('0x' + crypto.randomBytes(10).toString('hex')).toString(32).padStart(16, '0')
+            id: BigInt('0x' + crypto.randomBytes(10).toString('hex'))
+                .toString(32)
+                .padStart(16, '0')
         };
 
         if (
@@ -366,13 +374,65 @@ class SMTPServer extends EventEmitter {
 
         let chunks = [];
         let chunklen = 0;
-        let socketReader = () => {
+        let finished = false;
+
+        let onError;
+        let onClose;
+        let socketReader;
+
+        let cleanup = () => {
+            socket.removeListener('readable', socketReader);
+            socket.removeListener('error', onError);
+            socket.removeListener('close', onClose);
+        };
+
+        let done = (err, opts) => {
+            if (finished) {
+                return;
+            }
+            finished = true;
+            if (err) {
+                // The socket is already closing/closed (RST/FIN seen, or we
+                // issued socket.end() with a diagnostic). Attach a no-op 'error'
+                // handler BEFORE removing ours, so the socket is never left
+                // without one — a late in-flight error (e.g. EPIPE while
+                // flushing "* BAD") must not surface as an uncaughtException.
+                socket.on('error', () => {
+                    // ignore
+                });
+            }
+            cleanup();
+            callback(err, opts);
+        };
+
+        onError = err => {
+            // client may close the connection (RST/FIN) before sending the
+            // PROXY header; surface the error through the callback instead of
+            // letting it bubble up as an uncaught exception
+            this.logger.info(
+                {
+                    tnx: 'proxy',
+                    cid: socketOptions.id,
+                    err
+                },
+                '[%s] PROXY socket error before header was received: %s',
+                socketOptions.id,
+                err.message
+            );
+            done(err);
+        };
+
+        onClose = () => {
+            // socket closed before a full PROXY header arrived
+            done(new Error('Socket closed before PROXY header was received'));
+        };
+
+        socketReader = () => {
             let chunk;
             while ((chunk = socket.read()) !== null) {
                 for (let i = 0, len = chunk.length; i < len; i++) {
                     let chr = chunk[i];
                     if (chr === 0x0a) {
-                        socket.removeListener('readable', socketReader);
                         chunks.push(chunk.slice(0, i + 1));
                         chunklen += i + 1;
                         let remainder = chunk.slice(i + 1);
@@ -390,7 +450,7 @@ class SMTPServer extends EventEmitter {
                             } catch {
                                 // ignore
                             }
-                            return;
+                            return done(new Error('Invalid PROXY header'));
                         }
 
                         if (params[1]) {
@@ -415,7 +475,7 @@ class SMTPServer extends EventEmitter {
                                 }
                             } catch {
                                 socket.end('* BAD Invalid PROXY header\r\n');
-                                return;
+                                return done(new Error('Invalid PROXY header'));
                             }
 
                             if (params[3]) {
@@ -423,7 +483,7 @@ class SMTPServer extends EventEmitter {
                             }
                         }
 
-                        return callback(null, socketOptions);
+                        return done(null, socketOptions);
                     }
                 }
                 chunks.push(chunk);
@@ -431,6 +491,8 @@ class SMTPServer extends EventEmitter {
             }
         };
         socket.on('readable', socketReader);
+        socket.on('error', onError);
+        socket.on('close', onClose);
     }
 
     /**

--- a/test/smtp-connection-test.js
+++ b/test/smtp-connection-test.js
@@ -1616,6 +1616,118 @@ describe('SMTPServer', function () {
                 socket.write('PROXY TCP4 1.2.3.4 203.0.113.7 35646 80\r\n');
             });
         });
+
+        it('should deliver "* BAD" diagnostic before closing on invalid PROXY header', function (done) {
+            // A garbage (non-PROXY) header must still receive the diagnostic
+            // line: the socket is closed via end() and must not be destroy()ed
+            // before that buffered line is flushed to the client.
+            let socket = net.connect(PORT, '127.0.0.1', function () {
+                let buffers = [];
+                socket.on('data', function (chunk) {
+                    buffers.push(chunk);
+                });
+                socket.on('end', function () {
+                    let data = Buffer.concat(buffers).toString();
+                    expect(data.indexOf('* BAD Invalid PROXY header')).to.equal(0);
+                    done();
+                });
+                socket.write('NOTPROXY garbage line\r\n');
+            });
+            socket.on('error', function () {});
+        });
+
+        it('should not crash when client RSTs before sending PROXY header', function (done) {
+            // Regression test: previously the socket inside _handleProxy had
+            // no 'error' listener, so a client that reset the connection
+            // before the PROXY header arrived bubbled up as an
+            // uncaughtException and tore down the process.
+            //
+            // The deterministic signal is _handleProxy invoking its callback
+            // with an error: that means the server saw the broken socket and
+            // routed it through the error path instead of crashing.
+            let prevHandleProxy = server._handleProxy;
+
+            let onUncaught;
+            let onServerError;
+
+            function cleanup() {
+                process.removeListener('uncaughtException', onUncaught);
+                server.removeListener('error', onServerError);
+                server._handleProxy = prevHandleProxy;
+            }
+
+            onUncaught = function (err) {
+                cleanup();
+                done(new Error('uncaughtException leaked from _handleProxy: ' + err.message));
+            };
+
+            onServerError = function (err) {
+                cleanup();
+                done(new Error('server emitted error: ' + err.message));
+            };
+
+            process.once('uncaughtException', onUncaught);
+            server.on('error', onServerError);
+
+            server._handleProxy = function (sock, cb) {
+                return prevHandleProxy.call(this, sock, function (err, opts) {
+                    if (err) {
+                        cleanup();
+                        done();
+                        return;
+                    }
+                    return cb(err, opts);
+                });
+            };
+
+            let socket = net.connect(PORT, '127.0.0.1', function () {
+                // partial header, then force a RST instead of a clean FIN
+                socket.write('PROXY TCP4 1.2.3.4');
+                if (typeof socket.resetAndDestroy === 'function') {
+                    socket.resetAndDestroy();
+                } else {
+                    socket.destroy(new Error('boom'));
+                }
+            });
+            socket.on('error', function () {
+                // expected on the client side
+            });
+        });
+
+        it('should not invoke onConnect when client closes before PROXY header', function (done) {
+            // If the socket FINs before we ever see a newline-terminated PROXY
+            // header, the connection should be aborted silently — onConnect
+            // must not fire, and the process must not crash.
+            let connectFired = false;
+            let prevOnConnect = server.options.onConnect;
+            server.options.onConnect = function (session, cb) {
+                connectFired = true;
+                cb();
+            };
+
+            // _handleProxy invoking its callback with an error is the
+            // deterministic signal: the error and the (erroneous) connect path
+            // are mutually exclusive branches of that same callback, so once we
+            // see the error we know connect was not taken — no timer needed.
+            let prevHandleProxy = server._handleProxy;
+            server._handleProxy = function (sock, cb) {
+                return prevHandleProxy.call(this, sock, function (err, opts) {
+                    if (err) {
+                        server.options.onConnect = prevOnConnect;
+                        server._handleProxy = prevHandleProxy;
+                        expect(connectFired).to.equal(false);
+                        done();
+                        return;
+                    }
+                    return cb(err, opts);
+                });
+            };
+
+            let socket = net.connect(PORT, '127.0.0.1', function () {
+                socket.end(); // graceful close, no PROXY header sent
+            });
+            socket.on('error', function () {});
+        });
     });
 
     describe('Secure PROXY server', function () {


### PR DESCRIPTION
 ## Problem

  When `useProxy` is enabled, `_handleProxy` attached only a `'readable'`
  listener to the raw socket while waiting for the PROXY protocol header — no
  `'error'` listener.

  If the client reset (RST) or closed the connection before a complete,
  newline-terminated PROXY header arrived, the socket emitted `'error'` with no
  handler attached. Node re-throws an unhandled `'error'` as an
  `uncaughtException`, which crashes the whole server process. This is easy to
  hit behind TCP load balancers and health checks that routinely open and
  immediately reset connections.

  Secondary issue: the invalid-header branches called `socket.end('* BAD ...')`
  and then `return`ed **without invoking the callback**, so the connection was
  never routed to `connect()` nor cleaned up, lingering until `socketTimeout`.

  ## Fix

  - Attach `'error'` and `'close'` listeners during the PROXY-header read.
  - Funnel every outcome (parsed header / invalid header / error / close)
  through a single **idempotent** `done()` callback that removes all three
  listeners exactly once.
  - On the error path, attach a no-op `'error'` handler **before** removing
  ours, so the socket is never left without an `'error'` listener — a late
  in-flight error (e.g. EPIPE while flushing the `* BAD` diagnostic) can't
  surface as an `uncaughtException`.
  - Invalid-header branches now invoke the callback with an error instead of
  silently returning, so the socket no longer lingers.

  No `destroy()` is forced: in every error path the socket is already
  closing/closed (we saw `error`/`close`, or issued `socket.end()`), so the
  buffered `* BAD Invalid PROXY header` diagnostic is still delivered to the
  client.

  ## Tests

  Added regression tests to `test/smtp-connection-test.js`:

  - client RSTs after a partial PROXY header → no `uncaughtException`, no
  server-level `'error'`;
  - client FINs before any header → `onConnect` does not fire;
  - invalid (non-PROXY) header → client still receives the `* BAD Invalid PROXY
  header` diagnostic before close.


  Fixes [#257](https://github.com/nodemailer/smtp-server/issues/257)